### PR TITLE
Remove metric fields

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -9,7 +9,7 @@ Base.iterate(k::Kernel, ::Any) = nothing
 for k in [:ExponentialKernel,:SqExponentialKernel,:GammaExponentialKernel,:MaternKernel,:Matern32Kernel,:Matern52Kernel,:LinearKernel,:PolynomialKernel,:ExponentiatedKernel,:ZeroKernel,:WhiteKernel,:ConstantKernel,:RationalQuadraticKernel,:GammaRationalQuadraticKernel]
     @eval begin
         @inline (κ::$k)(d::Real) = kappa(κ,d) #TODO Add test
-        @inline (κ::$k)(x::AbstractVector{<:Real},y::AbstractVector{<:Real}) = kappa(κ,evaluate(κ.metric,transform(κ,x),transform(κ,y)))
+        @inline (κ::$k)(x::AbstractVector{<:Real},y::AbstractVector{<:Real}) = kappa(κ,evaluate(metric(κ),transform(κ,x),transform(κ,y)))
         @inline (κ::$k)(X::AbstractMatrix{T},Y::AbstractMatrix{T};obsdim::Integer=defaultobs) where {T} = kernelmatrix(κ,X,Y,obsdim=obsdim)
         @inline (κ::$k)(X::AbstractMatrix{T};obsdim::Integer=defaultobs) where {T} = kernelmatrix(κ,X,obsdim=obsdim)
     end

--- a/src/kernels/constant.jl
+++ b/src/kernels/constant.jl
@@ -5,9 +5,9 @@ Create a kernel always returning zero
 """
 struct ZeroKernel{T,Tr} <: Kernel{T,Tr}
     transform::Tr
-    metric::Delta
+
     function ZeroKernel{T,Tr}(t::Tr) where {T,Tr<:Transform}
-        new{T,Tr}(t,Delta())
+        new{T,Tr}(t)
     end
 end
 
@@ -16,6 +16,8 @@ function ZeroKernel(t::Tr=IdentityTransform()) where {Tr<:Transform}
 end
 
 @inline kappa(κ::ZeroKernel,d::T) where {T<:Real} = zero(T)
+
+metric(::ZeroKernel) = Delta()
 
 """
 `WhiteKernel([tr=IdentityTransform()])`
@@ -27,9 +29,9 @@ Kernel function working as an equivalent to add white noise.
 """
 struct WhiteKernel{T,Tr} <: Kernel{T,Tr}
     transform::Tr
-    metric::Delta
+
     function WhiteKernel{T,Tr}(t::Tr) where {T,Tr<:Transform}
-        new{T,Tr}(t,Delta())
+        new{T,Tr}(t)
     end
 end
 
@@ -38,6 +40,8 @@ function WhiteKernel(t::Tr=IdentityTransform()) where {Tr<:Transform}
 end
 
 @inline kappa(κ::WhiteKernel,δₓₓ::Real) = δₓₓ
+
+metric(::WhiteKernel) = Delta()
 
 """
 `ConstantKernel([tr=IdentityTransform(),[c=1.0]])`
@@ -48,10 +52,10 @@ Kernel function always returning a constant value `c`
 """
 struct ConstantKernel{T,Tr,Tc<:Real} <: Kernel{T,Tr}
     transform::Tr
-    metric::Delta
     c::Tc
+
     function ConstantKernel{T,Tr,Tc}(t::Tr,c::Tc) where {T,Tr<:Transform,Tc<:Real}
-        new{T,Tr,Tc}(t,Delta(),c)
+        new{T,Tr,Tc}(t,c)
     end
 end
 
@@ -67,3 +71,5 @@ function ConstantKernel(t::Tr,c::Tc=1.0) where {Tr<:Transform,Tc<:Real}
 end
 
 @inline kappa(κ::ConstantKernel,x::Real) = κ.c
+
+metric(::ConstantKernel) = Delta()

--- a/src/kernels/exponential.jl
+++ b/src/kernels/exponential.jl
@@ -10,14 +10,16 @@ related form of the kernel or [`GammaExponentialKernel`](@ref) for a generalizat
 """
 struct SqExponentialKernel{T,Tr} <: Kernel{T,Tr}
     transform::Tr
-    metric::SqEuclidean
+
     function SqExponentialKernel{T,Tr}(transform::Tr) where {T,Tr<:Transform}
-        return new{T,Tr}(transform,SqEuclidean())
+        return new{T,Tr}(transform)
     end
 end
 
 @inline kappa(κ::SqExponentialKernel, d²::Real) = exp(-d²)
 @inline iskroncompatible(::SqExponentialKernel) = true
+
+metric(::SqExponentialKernel) = SqEuclidean()
 
 ## Aliases ##
 const RBFKernel = SqExponentialKernel
@@ -32,14 +34,15 @@ The exponential kernel is an isotropic Mercer kernel given by the formula:
 """
 struct ExponentialKernel{T,Tr} <: Kernel{T,Tr}
     transform::Tr
-    metric::Euclidean
+
     function ExponentialKernel{T,Tr}(transform::Tr) where {T,Tr<:Transform}
-        return new{T,Tr}(transform,Euclidean())
+        return new{T,Tr}(transform)
     end
 end
 
 @inline kappa(κ::ExponentialKernel, d::Real) = exp(-d)
 @inline iskroncompatible(::ExponentialKernel) = true
+metric(::ExponentialKernel) = Euclidean()
 
 ## Alias ##
 const LaplacianKernel = ExponentialKernel
@@ -53,10 +56,10 @@ The γ-exponential kernel is an isotropic Mercer kernel given by the formula:
 """
 struct GammaExponentialKernel{T,Tr,Tᵧ<:Real} <: Kernel{T,Tr}
     transform::Tr
-    metric::SqEuclidean
     γ::Tᵧ
+
     function GammaExponentialKernel{T,Tr,Tᵧ}(transform::Tr,γ::Tᵧ) where {T,Tr<:Transform,Tᵧ<:Real}
-        return new{T,Tr,Tᵧ}(transform,SqEuclidean(),γ)
+        return new{T,Tr,Tᵧ}(transform,γ)
     end
 end
 
@@ -80,3 +83,4 @@ end
 
 @inline kappa(κ::GammaExponentialKernel, d²::Real) = exp(-d²^κ.γ)
 @inline iskroncompatible(::GammaExponentialKernel) = true
+metric(::GammaExponentialKernel) = SqEuclidean()

--- a/src/kernels/exponentiated.jl
+++ b/src/kernels/exponentiated.jl
@@ -7,9 +7,11 @@ The exponentiated kernel is a Mercer kernel given by:
 """
 struct ExponentiatedKernel{T,Tr} <: Kernel{T,Tr}
     transform::Tr
-    metric::DotProduct
+
     function ExponentiatedKernel{T,Tr}(transform::Tr) where {T,Tr<:Transform}
-        return new{T,Tr}(transform,DotProduct())
+        return new{T,Tr}(transform)
     end
 end
 @inline kappa(κ::ExponentiatedKernel, xᵀy::T) where {T<:Real} = exp(xᵀy)
+
+metric(::ExponentiatedKernel) = DotProduct()

--- a/src/kernels/matern.jl
+++ b/src/kernels/matern.jl
@@ -8,10 +8,10 @@ For `ν=n+1/2, n=0,1,2,...` it can be simplified and you should instead use [`Ex
 """
 struct MaternKernel{T,Tr,Tν<:Real} <: Kernel{T,Tr}
     transform::Tr
-    metric::Euclidean
     ν::Tν
+
     function MaternKernel{T,Tr,Tν}(transform::Tr,ν::Tν) where {T,Tr<:Transform,Tν<:Real}
-        return new{T,Tr,Tν}(transform,Euclidean(),ν)
+        return new{T,Tr,Tν}(transform,ν)
     end
 end
 
@@ -35,6 +35,8 @@ opt_params(k::MaternKernel) = (opt_params(transform(k)),k.ν)
 
 @inline kappa(κ::MaternKernel, d::Real) = iszero(d) ? one(d) : exp((1.0-κ.ν)*logtwo-lgamma(κ.ν) + κ.ν*log(sqrt(2κ.ν)*d)+log(besselk(κ.ν,sqrt(2κ.ν)*d)))
 
+metric(::MaternKernel) = Euclidean()
+
 """
 `Matern32Kernel([ρ=1.0])`
 The matern 3/2 kernel is an isotropic Mercer kernel given by the formula:
@@ -44,13 +46,15 @@ The matern 3/2 kernel is an isotropic Mercer kernel given by the formula:
 """
 struct Matern32Kernel{T,Tr} <: Kernel{T,Tr}
     transform::Tr
-    metric::Euclidean
+
     function Matern32Kernel{T,Tr}(transform::Tr) where {T,Tr<:Transform}
-        return new{T,Tr}(transform,Euclidean())
+        return new{T,Tr}(transform)
     end
 end
 
 @inline kappa(κ::Matern32Kernel, d::T) where {T<:Real} = (1+sqrt(3)*d)*exp(-sqrt(3)*d)
+
+metric(::Matern32Kernel) = Euclidean()
 
 """
 `Matern52Kernel([ρ=1.0])`
@@ -61,10 +65,12 @@ The matern 5/2 kernel is an isotropic Mercer kernel given by the formula:
 """
 struct Matern52Kernel{T,Tr} <: Kernel{T,Tr}
     transform::Tr
-    metric::Euclidean
+
     function Matern52Kernel{T,Tr}(transform::Tr) where {T,Tr<:Transform}
-        return new{T,Tr}(transform,Euclidean())
+        return new{T,Tr}(transform)
     end
 end
 
 @inline kappa(κ::Matern52Kernel, d::Real) where {T} = (1+sqrt(5)*d+5*d^2/3)*exp(-sqrt(5)*d)
+
+metric(::Matern52Kernel) = Euclidean()

--- a/src/kernels/polynomial.jl
+++ b/src/kernels/polynomial.jl
@@ -8,10 +8,10 @@ Where `c` is a real number
 """
 struct LinearKernel{T,Tr,Tc<:Real} <: Kernel{T,Tr}
     transform::Tr
-    metric::DotProduct
     c::Tc
+
     function LinearKernel{T,Tr,Tc}(transform::Tr,c::Tc) where {T,Tr<:Transform,Tc<:Real}
-        return new{T,Tr,Tc}(transform,DotProduct(),c)
+        return new{T,Tr,Tc}(transform,c)
     end
 end
 
@@ -32,6 +32,8 @@ opt_params(k::LinearKernel) = (opt_params(transform(k)),k.c)
 
 @inline kappa(κ::LinearKernel, xᵀy::T) where {T<:Real} = xᵀy + κ.c
 
+metric(::LinearKernel) = DotProduct()
+
 """
 `PolynomialKernel([ρ=1.0[,d=2.0[,c=0.0]]])`
 The polynomial kernel is a Mercer kernel given by
@@ -42,11 +44,11 @@ Where `c` is a real number, and `d` is a shape parameter bigger than 1
 """
 struct PolynomialKernel{T,Tr,Tc<:Real,Td<:Real} <: Kernel{T,Tr}
     transform::Tr
-    metric::DotProduct
     c::Tc
     d::Td
+
     function PolynomialKernel{T,Tr,Tc,Td}(transform::Tr,c::Tc,d::Td) where {T,Tr<:Transform,Tc<:Real,Td<:Real}
-        return new{T,Tr,Tc,Td}(transform,DotProduct(),c,d)
+        return new{T,Tr,Tc,Td}(transform,c,d)
     end
 end
 
@@ -69,3 +71,5 @@ params(k::PolynomialKernel) = (params(transform(k)),k.d,k.c)
 opt_params(k::PolynomialKernel) = (opt_params(transform(k)),k.d,k.c)
 
 @inline kappa(κ::PolynomialKernel, xᵀy::T) where {T<:Real} = (xᵀy + κ.c)^(κ.d)
+
+metric(::PolynomialKernel) = DotProduct()

--- a/src/kernels/rationalquad.jl
+++ b/src/kernels/rationalquad.jl
@@ -8,10 +8,10 @@ where `α` is a shape parameter of the Euclidean distance. Check [`GammaRational
 """
 struct RationalQuadraticKernel{T,Tr,Tα<:Real} <: Kernel{T,Tr}
     transform::Tr
-    metric::SqEuclidean
     α::Tα
+
     function RationalQuadraticKernel{T,Tr,Tα}(t::Tr,α::Tα) where {T,Tr,Tα<:Real}
-        new{T,Tr,Tα}(t,SqEuclidean(),α)
+        new{T,Tr,Tα}(t,α)
     end
 end
 
@@ -35,6 +35,7 @@ opt_params(k::RationalQuadraticKernel) = (opt_params(transform(k)),k.α)
 
 @inline kappa(κ::RationalQuadraticKernel, d²::T) where {T<:Real} = (one(T)+d²/κ.α)^(-κ.α)
 
+metric(::RationalQuadraticKernel) = SqEuclidean()
 
 """
 `GammaRationalQuadraticKernel([ρ=1.0[,α=2.0[,γ=2.0]]])`
@@ -46,11 +47,11 @@ where `α` is a shape parameter of the Euclidean distance and `γ` is another sh
 """
 struct GammaRationalQuadraticKernel{T,Tr,Tα<:Real,Tγ<:Real} <: Kernel{T,Tr}
     transform::Tr
-    metric::SqEuclidean
     α::Tα
     γ::Tγ
+
     function GammaRationalQuadraticKernel{T,Tr,Tα,Tγ}(t::Tr,α::Tα,γ::Tγ) where {T,Tr,Tα<:Real,Tγ<:Real}
-        new{T,Tr,Tα,Tγ}(t,SqEuclidean(),α,γ)
+        new{T,Tr,Tα,Tγ}(t,α,γ)
     end
 end
 
@@ -76,3 +77,5 @@ params(k::GammaRationalQuadraticKernel) = (params(k.transform),k.α,k.γ)
 opt_params(k::GammaRationalQuadraticKernel) = (opt_params(k.transform),k.α,k.γ)
 
 @inline kappa(κ::GammaRationalQuadraticKernel, d²::T) where {T<:Real} = (one(T)+d²^κ.γ/κ.α)^(-κ.α)
+
+metric(::GammaRationalQuadraticKernel) = SqEuclidean()


### PR DESCRIPTION
It seems the `metric` fields are not needed, it is sufficient to define the `metric(::Kernel)` trait.