### PR TITLE
Ease implementation of custom kernels

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -5,11 +5,14 @@ Base.length(::Kernel) = 1
 Base.iterate(k::Kernel) = (k,nothing)
 Base.iterate(k::Kernel, ::Any) = nothing
 
+# default fallback for evaluating a kernel with two arguments (such as vectors etc)
+kappa(κ::Kernel, x, y) = kappa(κ, evaluate(metric(κ), transform(κ, x), transform(κ, y)))
+
 ### Syntactic sugar for creating matrices and using kernel functions
 for k in [:ExponentialKernel,:SqExponentialKernel,:GammaExponentialKernel,:MaternKernel,:Matern32Kernel,:Matern52Kernel,:LinearKernel,:PolynomialKernel,:ExponentiatedKernel,:ZeroKernel,:WhiteKernel,:ConstantKernel,:RationalQuadraticKernel,:GammaRationalQuadraticKernel]
     @eval begin
         @inline (κ::$k)(d::Real) = kappa(κ,d) #TODO Add test
-        @inline (κ::$k)(x::AbstractVector{<:Real},y::AbstractVector{<:Real}) = kappa(κ,evaluate(metric(κ),transform(κ,x),transform(κ,y)))
+        @inline (κ::$k)(x::AbstractVector{<:Real}, y::AbstractVector{<:Real}) = kappa(κ, x, y)
         @inline (κ::$k)(X::AbstractMatrix{T},Y::AbstractMatrix{T};obsdim::Integer=defaultobs) where {T} = kernelmatrix(κ,X,Y,obsdim=obsdim)
         @inline (κ::$k)(X::AbstractMatrix{T};obsdim::Integer=defaultobs) where {T} = kernelmatrix(κ,X,obsdim=obsdim)
     end

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -26,7 +26,8 @@ end
 ## Constructors for kernels without parameters
 for kernel in [:ExponentialKernel,:SqExponentialKernel,:Matern32Kernel,:Matern52Kernel,:ExponentiatedKernel]
     @eval begin
-        $kernel(ρ::Real=1.0) = $kernel(ScaleTransform(ρ))
+        $kernel() = $kernel(IdentityTransform())
+        $kernel(ρ::Real) = $kernel(ScaleTransform(ρ))
         $kernel(ρ::AbstractVector{<:Real}) = $kernel(ARDTransform(ρ))
     end
 end

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -17,8 +17,8 @@ end
 
 ### Transform generics
 @inline transform(κ::Kernel) = κ.transform
-@inline transform(κ::Kernel,x::AbstractVecOrMat) = transform(κ.transform,x)
-@inline transform(κ::Kernel,x::AbstractVecOrMat,obsdim::Int) = transform(κ.transform,x,obsdim)
+@inline transform(κ::Kernel, x) = transform(transform(κ), x)
+@inline transform(κ::Kernel, x, obsdim::Int) = transform(transform(κ), x, obsdim)
 
 ## Constructors for kernels without parameters
 for kernel in [:ExponentialKernel,:SqExponentialKernel,:Matern32Kernel,:Matern52Kernel,:ExponentiatedKernel]

--- a/src/transform/transform.jl
+++ b/src/transform/transform.jl
@@ -26,7 +26,7 @@ struct IdentityTransform <: Transform end
 params(t::IdentityTransform) = nothing
 duplicate(t::IdentityTransform,θ) = t
 
-transform(t::IdentityTransform,x::AbstractArray,obsdim::Int=defaultobs) = x #TODO add test
+transform(t::IdentityTransform, x, obsdim::Int=defaultobs) = x #TODO add test
 
 ### TODO Maybe defining adjoints could help but so far it's not working
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -28,7 +28,7 @@ feature_dim(obsdim::Int) = obsdim == 1 ? 2 : 1
 
 base_kernel(k::Kernel) = eval(nameof(typeof(k)))
 
-base_transform(k::Kernel) = base_transform(k.transform)
+base_transform(k::Kernel) = base_transform(transform(k))
 base_transform(t::Transform) = eval(nameof(typeof(t)))
 _tail(v::AbstractVector) = view(v,2:length(v))
 
@@ -56,4 +56,4 @@ dim(k::Kernel) = length(params(k))
 For a kernel return a tuple with parameters of the transform followed by the specific parameters of the kernel
 For a transform return its parameters, for a `ChainTransform` return a vector of `params(t)`.
 """
-params(k::Kernel) = (params(k.transform),)
+params(k::Kernel) = (params(transform(k)),)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,5 +12,6 @@ include("test_distances.jl")
 include("test_kernels.jl")
 include("test_generic.jl")
 include("test_adjoints.jl")
+include("test_custom.jl")
     #include("types.jl")
 end

--- a/test/test_custom.jl
+++ b/test/test_custom.jl
@@ -1,0 +1,26 @@
+using KernelFunctions
+using Test
+
+# minimal definition of a custom kernel
+struct MyKernel <: Kernel{IdentityTransform} end
+
+KernelFunctions.kappa(::MyKernel, d2::Real) = exp(-d2)
+KernelFunctions.metric(::MyKernel) = SqEuclidean()
+KernelFunctions.transform(::MyKernel) = IdentityTransform()
+
+@test kappa(MyKernel(), 3) == kappa(SqExponentialKernel(), 3)
+@test kappa(MyKernel(), 1, 3) == kappa(SqExponentialKernel(), 1, 3)
+@test kappa(MyKernel(), [1, 2], [3, 4]) == kappa(SqExponentialKernel(), [1, 2], [3, 4])
+@test kernelmatrix(MyKernel(), [1 2; 3 4], [5 6; 7 8]) == kernelmatrix(SqExponentialKernel(), [1 2; 3 4], [5 6; 7 8])
+@test kernelmatrix(MyKernel(), [1 2; 3 4]) == kernelmatrix(SqExponentialKernel(), [1 2; 3 4])
+
+# some syntactic sugar
+(κ::MyKernel)(d::Real) = kappa(κ, d)
+(κ::MyKernel)(x::AbstractVector{<:Real}, y::AbstractVector{<:Real}) = kappa(κ, x, y)
+(κ::MyKernel)(X::AbstractMatrix{<:Real}, Y::AbstractMatrix{<:Real}; obsdim = 2) = kernelmatrix(κ, X, Y; obsdim = obsdim)
+(κ::MyKernel)(X::AbstractMatrix{<:Real}; obsdim = 2) = kernelmatrix(κ, X; obsdim = obsdim)
+
+@test MyKernel()(3) == SqExponentialKernel()(3)
+@test MyKernel()([1, 2], [3, 4]) == SqExponentialKernel()([1, 2], [3, 4])
+@test MyKernel()([1 2; 3 4], [5 6; 7 8]) == SqExponentialKernel()([1 2; 3 4], [5 6; 7 8])
+@test MyKernel()([1 2; 3 4]) == SqExponentialKernel()([1 2; 3 4])


### PR DESCRIPTION
The main purpose of this PR is to simplify the implementation of custom kernels, in particular if they use a fixed transform. I added a test with a reimplementation of a squared exponential kernel with fixed identity transform to illustrate the minimum implementation that is currently required.

The main changes in this PR are
- the removal of (hopefully) all accesses of a `transform` field in generic methods,
- the definition of a default method for evaluating kernels with two inputs that makes use of the metric and transform of a kernel and is not restricted to arrays (hence could be used with real numbers or distributions as well),
- the use of the identity transform as default transform for kernels without parameters instead of `ScaleTransform(1.0)`,
- the possibility to apply an `IdentityTransform` to arbitrary types (hence it can be applied, e.g., also to real numbers and distributions).

I still think that it might be better to not have to define a transformation at all, IMO it would be more natural to be able to just define
```julia
struct MyKernel <: Kernel end

KernelFunctions.kappa(::MyKernel, d2::Real) = exp(-d2)
KernelFunctions.metric(::MyKernel) = SqEuclidean()
```