### PR TITLE
Fix PDMats warning

### DIFF
--- a/src/matrix/kernelpdmat.jl
+++ b/src/matrix/kernelpdmat.jl
@@ -1,4 +1,4 @@
-using PDMats: PDMat
+using .PDMats: PDMat
 
 export kernelpdmat
 


### PR DESCRIPTION
This PR fixes the warning
```julia
┌ Warning: Error requiring PDMats from KernelFunctions:
│ LoadError: ArgumentError: Package KernelFunctions does not have PDMats in its dependencies:
│ - If you have KernelFunctions checked out for development and have
│   added PDMats as a dependency but haven't updated your primary
│   environment's manifest file, try `Pkg.resolve()`.
│ - Otherwise you may need to report an issue with KernelFunctions
```