### PR TITLE
Add non-unicode keywords aliases

### DIFF
--- a/src/kernels/exponential.jl
+++ b/src/kernels/exponential.jl
@@ -20,6 +20,7 @@ Base.show(io::IO,::SqExponentialKernel) = print(io,"Squared Exponential Kernel")
 ## Aliases ##
 const RBFKernel = SqExponentialKernel
 const GaussianKernel = SqExponentialKernel
+const SEKernel = SqExponentialKernel
 
 """
 `ExponentialKernel([ρ=1.0])`
@@ -48,7 +49,7 @@ The γ-exponential kernel is an isotropic Mercer kernel given by the formula:
 """
 struct GammaExponentialKernel{Tγ<:Real} <: BaseKernel
     γ::Vector{Tγ}
-    function GammaExponentialKernel(;γ::T=2.0) where {T<:Real}
+    function GammaExponentialKernel(;gamma::T=2.0,γ::T=gamma) where {T<:Real}
         @check_args(GammaExponentialKernel, γ, γ >= zero(T), "γ > 0")
         return new{T}([γ])
     end

--- a/src/kernels/exponential.jl
+++ b/src/kernels/exponential.jl
@@ -49,7 +49,7 @@ The γ-exponential kernel is an isotropic Mercer kernel given by the formula:
 """
 struct GammaExponentialKernel{Tγ<:Real} <: BaseKernel
     γ::Vector{Tγ}
-    function GammaExponentialKernel(;gamma::T=2.0,γ::T=gamma) where {T<:Real}
+    function GammaExponentialKernel(;gamma::T=2.0, γ::T=gamma) where {T<:Real}
         @check_args(GammaExponentialKernel, γ, γ >= zero(T), "γ > 0")
         return new{T}([γ])
     end

--- a/src/kernels/matern.jl
+++ b/src/kernels/matern.jl
@@ -8,7 +8,7 @@ For `ν=n+1/2, n=0,1,2,...` it can be simplified and you should instead use [`Ex
 """
 struct MaternKernel{Tν<:Real} <: BaseKernel
     ν::Vector{Tν}
-    function MaternKernel(;nu::T=1.5,ν::T=nu) where {T<:Real}
+    function MaternKernel(;nu::T=1.5, ν::T=nu) where {T<:Real}
         @check_args(MaternKernel, ν, ν > zero(T), "ν > 0")
         return new{T}([ν])
     end
@@ -16,7 +16,12 @@ end
 
 @inline function kappa(κ::MaternKernel, d::Real)
     ν = first(κ.ν)
-    iszero(d) ? one(d) : exp((one(d)-ν)*logtwo-logabsgamma(ν)[1] + ν*log(sqrt(2ν)*d)+log(besselk(ν,sqrt(2ν)*d)))
+    iszero(d) ? one(d) :
+    exp(
+        (one(d) - ν) * logtwo - logabsgamma(ν)[1] +
+        ν * log(sqrt(2ν) * d) +
+        log(besselk(ν, sqrt(2ν) * d))
+    )
 end
 
 metric(::MaternKernel) = Euclidean()
@@ -30,7 +35,7 @@ The matern 3/2 kernel is an isotropic Mercer kernel given by the formula:
 """
 struct Matern32Kernel <: BaseKernel end
 
-kappa(κ::Matern32Kernel, d::Real) = (1+sqrt(3)*d)*exp(-sqrt(3)*d)
+kappa(κ::Matern32Kernel, d::Real) = (1 + sqrt(3) * d) * exp(-sqrt(3) * d)
 
 metric(::Matern32Kernel) = Euclidean()
 
@@ -43,6 +48,6 @@ The matern 5/2 kernel is an isotropic Mercer kernel given by the formula:
 """
 struct Matern52Kernel <: BaseKernel end
 
-kappa(κ::Matern52Kernel, d::Real) = (1+sqrt(5)*d+5*d^2/3)*exp(-sqrt(5)*d)
+kappa(κ::Matern52Kernel, d::Real) = (1 + sqrt(5) * d + 5 * d^2 / 3) * exp(-sqrt(5) * d)
 
 metric(::Matern52Kernel) = Euclidean()

--- a/src/kernels/matern.jl
+++ b/src/kernels/matern.jl
@@ -8,7 +8,7 @@ For `ν=n+1/2, n=0,1,2,...` it can be simplified and you should instead use [`Ex
 """
 struct MaternKernel{Tν<:Real} <: BaseKernel
     ν::Vector{Tν}
-    function MaternKernel(;ν::T=1.5) where {T<:Real}
+    function MaternKernel(;nu::T=1.5,ν::T=nu) where {T<:Real}
         @check_args(MaternKernel, ν, ν > zero(T), "ν > 0")
         return new{T}([ν])
     end

--- a/src/kernels/rationalquad.jl
+++ b/src/kernels/rationalquad.jl
@@ -8,7 +8,7 @@ where `α` is a shape parameter of the Euclidean distance. Check [`GammaRational
 """
 struct RationalQuadraticKernel{Tα<:Real} <: BaseKernel
     α::Vector{Tα}
-    function RationalQuadraticKernel(;alpha::T=2.0,α::T=alpha) where {T}
+    function RationalQuadraticKernel(;alpha::T=2.0, α::T=alpha) where {T}
         @check_args(RationalQuadraticKernel, α, α > zero(T), "α > 1")
         return new{T}([α])
     end
@@ -29,7 +29,7 @@ where `α` is a shape parameter of the Euclidean distance and `γ` is another sh
 struct GammaRationalQuadraticKernel{Tα<:Real, Tγ<:Real} <: BaseKernel
     α::Vector{Tα}
     γ::Vector{Tγ}
-    function GammaRationalQuadraticKernel(;alpha::Tα=2.0,gamma::Tγ=2.0,α::Tα=alpha, γ::Tγ=gamma) where {Tα<:Real, Tγ<:Real}
+    function GammaRationalQuadraticKernel(;alpha::Tα=2.0, gamma::Tγ=2.0, α::Tα=alpha, γ::Tγ=gamma) where {Tα<:Real, Tγ<:Real}
         @check_args(GammaRationalQuadraticKernel, α, α > one(Tα), "α > 1")
         @check_args(GammaRationalQuadraticKernel, γ, γ >= one(Tγ), "γ >= 1")
         return new{Tα, Tγ}([α], [γ])

--- a/src/kernels/rationalquad.jl
+++ b/src/kernels/rationalquad.jl
@@ -8,7 +8,7 @@ where `α` is a shape parameter of the Euclidean distance. Check [`GammaRational
 """
 struct RationalQuadraticKernel{Tα<:Real} <: BaseKernel
     α::Vector{Tα}
-    function RationalQuadraticKernel(;α::T=2.0) where {T}
+    function RationalQuadraticKernel(;alpha::T=2.0,α::T=alpha) where {T}
         @check_args(RationalQuadraticKernel, α, α > zero(T), "α > 1")
         return new{T}([α])
     end
@@ -29,7 +29,7 @@ where `α` is a shape parameter of the Euclidean distance and `γ` is another sh
 struct GammaRationalQuadraticKernel{Tα<:Real, Tγ<:Real} <: BaseKernel
     α::Vector{Tα}
     γ::Vector{Tγ}
-    function GammaRationalQuadraticKernel(;α::Tα=2.0, γ::Tγ=2.0) where {Tα<:Real, Tγ<:Real}
+    function GammaRationalQuadraticKernel(;alpha::Tα=2.0,gamma::Tγ=2.0,α::Tα=alpha, γ::Tγ=gamma) where {Tα<:Real, Tγ<:Real}
         @check_args(GammaRationalQuadraticKernel, α, α > one(Tα), "α > 1")
         @check_args(GammaRationalQuadraticKernel, γ, γ >= one(Tγ), "γ >= 1")
         return new{Tα, Tγ}([α], [γ])

--- a/test/test_kernels.jl
+++ b/test/test_kernels.jl
@@ -44,6 +44,7 @@ x = rand()*2; v1 = rand(3); v2 = rand(3); id = IdentityTransform()
             @test kappa(k,x) ≈ exp(-(x)^(γ))
             @test k(v1,v2) ≈ exp(-norm(v1-v2)^(2γ))
             @test kappa(GammaExponentialKernel(),x) == kappa(k,x)
+            @test GammaExponentialKernel(gamma=γ).γ == [γ]
             #Coherence :
             @test KernelFunctions._kernel(GammaExponentialKernel(γ=1.0),v1,v2) ≈ KernelFunctions._kernel(SqExponentialKernel(),v1,v2)
             @test KernelFunctions._kernel(GammaExponentialKernel(γ=0.5),v1,v2) ≈ KernelFunctions._kernel(ExponentialKernel(),v1,v2)
@@ -62,6 +63,7 @@ x = rand()*2; v1 = rand(3); v2 = rand(3); id = IdentityTransform()
             ν = 2.0
             k = MaternKernel(ν=ν)
             matern(x,ν) = 2^(1-ν)/gamma(ν)*(sqrt(2ν)*x)^ν*besselk(ν,sqrt(2ν)*x)
+            @test MaternKernel(nu=ν).ν == [ν]
             @test kappa(k,x) ≈ matern(x,ν)
             @test kappa(k,0.0) == 1.0
             @test kappa(MaternKernel(ν=ν),x) == kappa(k,x)
@@ -103,10 +105,12 @@ x = rand()*2; v1 = rand(3); v2 = rand(3); id = IdentityTransform()
     end
     @testset "RationalQuadratic" begin
         @testset "RationalQuadraticKernel" begin
-            k = RationalQuadraticKernel()
+            α = 2.0
+            k = RationalQuadraticKernel(α=α)
+            @test RationalQuadraticKernel(alpha=α).α == [α]
             @test kappa(k,x) ≈ (1.0+x/2.0)^-2
             @test k(v1,v2) ≈ (1.0+norm(v1-v2)^2/2.0)^-2
-            @test kappa(RationalQuadraticKernel(),x) == kappa(k,x)
+            @test kappa(RationalQuadraticKernel(α=α),x) == kappa(k,x)
         end
         @testset "GammaRationalQuadraticKernel" begin
             k = GammaRationalQuadraticKernel()
@@ -114,6 +118,7 @@ x = rand()*2; v1 = rand(3); v2 = rand(3); id = IdentityTransform()
             @test k(v1,v2) ≈ (1.0+norm(v1-v2)^4.0/2.0)^-2
             @test kappa(GammaRationalQuadraticKernel(),x) == kappa(k,x)
             a = 1.0 + rand()
+            @test GammaRationalQuadraticKernel(alpha=a).α == [a]
             #Coherence test
             @test kappa(GammaRationalQuadraticKernel(α=a,γ=1.0),x) ≈ kappa(RationalQuadraticKernel(α=a),x)
         end
@@ -128,7 +133,7 @@ x = rand()*2; v1 = rand(3); v2 = rand(3); id = IdentityTransform()
         @test kappa(kt,v1,v2) == kappa(transform(k,ScaleTransform(s)),v1,v2)
         @test kappa(kt,v1,v2) == kappa(transform(k,s),v1,v2)
         @test kappa(kt,v1,v2) == kappa(k,s*v1,s*v2)
-        @test kappa(ktard,v1,v2) == kappa(transform(k,ARDTransform(v)),v1,v2)
+        @test kappa(ktard,v1,v2) ≈ kappa(transform(k,ARDTransform(v)),v1,v2)
         @test kappa(ktard,v1,v2) == kappa(transform(k,v),v1,v2)
         @test kappa(ktard,v1,v2) == kappa(k,v.*v1,v.*v2)
         @test KernelFunctions.metric(kt) == KernelFunctions.metric(k)


### PR DESCRIPTION
Add alpha vs \alpha, gamma vs \gamma etc, for the concerned kernels.