### PR TITLE
Add alias to WhiteKernel, EyeKernel

### DIFF
--- a/src/KernelFunctions.jl
+++ b/src/KernelFunctions.jl
@@ -8,7 +8,7 @@ export transform
 export params, duplicate, set! # Helpers
 
 export Kernel
-export ConstantKernel, WhiteKernel, ZeroKernel
+export ConstantKernel, WhiteKernel, EyeKernel, ZeroKernel
 export SqExponentialKernel, ExponentialKernel, GammaExponentialKernel
 export ExponentiatedKernel
 export MaternKernel, Matern32Kernel, Matern52Kernel

--- a/src/kernels/constant.jl
+++ b/src/kernels/constant.jl
@@ -24,6 +24,7 @@ Kernel function working as an equivalent to add white noise.
 struct WhiteKernel <: BaseKernel end
 
 const EyeKernel = WhiteKernel
+export EyeKernel
 
 kappa(κ::WhiteKernel,δₓₓ::Real) = δₓₓ
 

--- a/src/kernels/constant.jl
+++ b/src/kernels/constant.jl
@@ -23,6 +23,8 @@ Kernel function working as an equivalent to add white noise.
 """
 struct WhiteKernel <: BaseKernel end
 
+const EyeKernel = WhiteKernel
+
 kappa(κ::WhiteKernel,δₓₓ::Real) = δₓₓ
 
 metric(::WhiteKernel) = Delta()

--- a/src/kernels/constant.jl
+++ b/src/kernels/constant.jl
@@ -24,7 +24,6 @@ Kernel function working as an equivalent to add white noise.
 struct WhiteKernel <: BaseKernel end
 
 const EyeKernel = WhiteKernel
-export EyeKernel
 
 kappa(κ::WhiteKernel,δₓₓ::Real) = δₓₓ
 

--- a/test/test_kernels.jl
+++ b/test/test_kernels.jl
@@ -16,6 +16,7 @@ x = rand()*2; v1 = rand(3); v2 = rand(3); id = IdentityTransform()
             @test eltype(k) == Any
             @test kappa(k,1.0) == 1.0
             @test kappa(k,0.0) == 0.0
+            @test EyeKernel == WhiteKernel
         end
         @testset "ConstantKernel" begin
             c = 2.0


### PR DESCRIPTION
Issue #44

From what I gather, [EyeKernel](https://github.com/alshedivat/gpml/blob/master/cov/covEye.m) is the same as already implemented `WhiteKernel`. Simply adding an alias.