### PR TITLE
Stop testing on 1.2, start on 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ os:
   - osx
 julia:
   - 1.0
-  - 1.2
   - 1.3
+  - 1.4
   - nightly
 # because of Zygote needs to allow failing on nightly
 matrix:


### PR DESCRIPTION
Now that 1.4 is out, we should be testing on it. I've stopped us testing on 1.2 -- seems reasonable not to continue to test on all minor versions of Julia.